### PR TITLE
Rebus Version 6 alignments

### DIFF
--- a/Rebus.Async.Tests/Rebus.Async.Tests.csproj
+++ b/Rebus.Async.Tests/Rebus.Async.Tests.csproj
@@ -30,7 +30,7 @@
     <ProjectReference Include="..\Rebus.Async\Rebus.Async.csproj" />
     <PackageReference Include="microsoft.net.test.sdk" Version="16.2.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="nunit3testadapter" Version="3.15.0" />
+    <PackageReference Include="nunit3testadapter" Version="3.15.1" />
     <PackageReference Include="rebus" Version="6.0.0-b16" />
     <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b16" />
   </ItemGroup>

--- a/Rebus.Async.Tests/Rebus.Async.Tests.csproj
+++ b/Rebus.Async.Tests/Rebus.Async.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="microsoft.net.test.sdk" Version="16.2.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="nunit3testadapter" Version="3.15.0" />
-    <PackageReference Include="rebus" Version="5.4.0" />
-    <PackageReference Include="rebus.tests.contracts" Version="5.2.0" />
+    <PackageReference Include="rebus" Version="6.0.0-b16" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b16" />
   </ItemGroup>
 </Project>

--- a/Rebus.Async.sln
+++ b/Rebus.Async.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29306.81
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{1ABDD7C1-1F8D-402D-8692-3E4B66962DE0}"
 	ProjectSection(SolutionItems) = preProject
@@ -10,9 +10,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "stuff", "stuff", "{1ABDD7C1
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.Async", "Rebus.Async\Rebus.Async.csproj", "{206BFBFD-DD80-4BAC-A50A-CAEE097DA9AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.Async", "Rebus.Async\Rebus.Async.csproj", "{206BFBFD-DD80-4BAC-A50A-CAEE097DA9AD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Rebus.Async.Tests", "Rebus.Async.Tests\Rebus.Async.Tests.csproj", "{029A88C4-9350-497E-8EE8-B6965C7D7A90}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Rebus.Async.Tests", "Rebus.Async.Tests\Rebus.Async.Tests.csproj", "{029A88C4-9350-497E-8EE8-B6965C7D7A90}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,5 +31,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {6436B807-CF70-42E0-B50A-CD534F4C2A09}
 	EndGlobalSection
 EndGlobal

--- a/Rebus.Async/AsyncBusExtensions.cs
+++ b/Rebus.Async/AsyncBusExtensions.cs
@@ -31,7 +31,7 @@ namespace Rebus
         /// <param name="optionalHeaders">Headers to be included in the request message</param>
         /// <param name="timeout">Optionally specifies the max time to wait for a reply. If this time is exceeded, a <see cref="TimeoutException"/> is thrown</param>
         /// <returns></returns>
-        public static async Task<TReply> SendRequest<TReply>(this IBus bus, object request, Dictionary<string, string> optionalHeaders = null, TimeSpan? timeout = null)
+        public static async Task<TReply> SendRequest<TReply>(this IBus bus, object request, IDictionary<string, string> optionalHeaders = null, TimeSpan? timeout = null)
         {
             var currentTransactionContext = AmbientTransactionContext.Current;
             try
@@ -45,7 +45,7 @@ namespace Rebus
             }
         }
 
-        static async Task<TReply> InnerSendRequest<TReply>(this IBus bus, object request, Dictionary<string, string> optionalHeaders = null, TimeSpan? timeout = null)
+        static async Task<TReply> InnerSendRequest<TReply>(this IBus bus, object request, IDictionary<string, string> optionalHeaders = null, TimeSpan? timeout = null)
         {
             var maxWaitTime = timeout ?? TimeSpan.FromSeconds(5);
             var messageId = $"{ReplyHandlerStep.SpecialMessageIdPrefix}_{Guid.NewGuid()}";

--- a/Rebus.Async/Rebus.Async.csproj
+++ b/Rebus.Async/Rebus.Async.csproj
@@ -41,7 +41,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="rebus" Version="5.0.0" />
+    <PackageReference Include="rebus" Version="6.0.0-b16" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
Changed signature of SendRequest method from Dictionary<string, string> to IDictionary<string, string> to match the signature of rebus version 6.
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
