### PR TITLE
Update Rebus to 6.0.0 and introduce the ability to cancel the wait fo…

### DIFF
--- a/Rebus.Async.Tests/Rebus.Async.Tests.csproj
+++ b/Rebus.Async.Tests/Rebus.Async.Tests.csproj
@@ -28,10 +28,13 @@
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Rebus.Async\Rebus.Async.csproj" />
-    <PackageReference Include="microsoft.net.test.sdk" Version="16.2.0" />
+    <PackageReference Include="microsoft.net.test.sdk" Version="16.5.0" />
     <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="nunit3testadapter" Version="3.15.1" />
-    <PackageReference Include="rebus" Version="6.0.0-b16" />
-    <PackageReference Include="rebus.tests.contracts" Version="6.0.0-b16" />
+    <PackageReference Include="nunit3testadapter" Version="3.16.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="rebus" Version="6.0.1" />
+    <PackageReference Include="rebus.tests.contracts" Version="6.0.0" />
   </ItemGroup>
 </Project>

--- a/Rebus.Async/Rebus.Async.csproj
+++ b/Rebus.Async/Rebus.Async.csproj
@@ -42,7 +42,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="rebus" Version="6.0.0-b16" />
+    <PackageReference Include="rebus" Version="6.0.1" />
   </ItemGroup>
   <Target Name="PreBuild" BeforeTargets="PreBuildEvent">
     <Exec Command="$(ProjectDir)..\scripts\patch_assemblyinfo.cmd $(ProjectDir)" />


### PR DESCRIPTION
Update Rebus to 6.0.0 and introduce the ability to cancel the wait for a reply based on an external cancellation token in addition to the timeout. The new ability is needed for the implementation of Rebus.SignalR backplane

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
