### PR TITLE
#27 fix url

### DIFF
--- a/Rebus.Async/Rebus.Async.csproj
+++ b/Rebus.Async/Rebus.Async.csproj
@@ -9,7 +9,7 @@
 		<Copyright>Copyright Rebus FM ApS 2012</Copyright>
 		<PackageTags>rebus events</PackageTags>
 		<PackageDescription>Provides extension for Rebus that enables "synchronous" (via async/await) request/response</PackageDescription>
-		<RepositoryUrl>https://github.com/rebus-org/Rebus</RepositoryUrl>
+		<RepositoryUrl>https://github.com/rebus-org/Rebus.Async</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>


### PR DESCRIPTION
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

Closes #27 